### PR TITLE
Feature restore Visual Studio nuget packages

### DIFF
--- a/PSDT.VisualStudio.psd1
+++ b/PSDT.VisualStudio.psd1
@@ -7,8 +7,8 @@
     Copyright = '(c) 2017 Tauri-Code. All rights reserved.'
     Description = 'A collection of Visual Studio related PowerShell developer tools.'
     RequiredModules = @("PSDT.App")
-    FunctionsToExport = @("Import-VSCommandPrompt","Get-VSSolution","Invoke-VSBuild","Invoke-VSTest")
+    FunctionsToExport = @("Import-VSCommandPrompt","Get-VSSolution","Invoke-VSBuild","Invoke-VSTest","Restore-VSSolutionNugetPackages")
     CmdletsToExport = @("*-*")
     VariablesToExport = '*'
-    AliasesToExport = @("gvss","ivsb","ivst")
+    AliasesToExport = @("gvss","ivsb","ivst","rvss")
 }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -54,7 +54,11 @@
       secure: 3uEUNJ8M0/Rdg1D2KT+XLjpWNr7QbTMO/8SjSXuAwbbeGW1UIfwLthZ0nzFSEpRl
   init:
   - ps: >-
-      Invoke-PSDTInitBuild;
+      Install-PackageProvider -Name NuGet -MinimumVersion '2.8.5.201' -Force;
+      Import-PackageProvider NuGet -MinimumVersion '2.8.5.201';
+      Set-PSRepository -Name PSGallery -InstallationPolicy Trusted;
+      Install-Module -Name PSScriptAnalyzer;
+      Install-Module -Name PSDT.AppVeyor;
   build_script:
   - ps: >-
       Invoke-PSDTPreBuild;


### PR DESCRIPTION
It's frequently necessary to restore nuget packages for specific solutions before we can build them. Using the nuget.exe separately is annoying. Implementing a separate module for nuget is in my opinion to much for now, so I've added a Resotre-VSSolutionNugetPackages cmdlet, which can be used standalone or together with Get-VSSolution and Invoke-VSBuild.