### PR TITLE
Add serach for MSBuild and VSTest with vswhere

### DIFF
--- a/PSDT.VisualStudio.psd1
+++ b/PSDT.VisualStudio.psd1
@@ -7,7 +7,7 @@
     Copyright = '(c) 2017 Tauri-Code. All rights reserved.'
     Description = 'A collection of Visual Studio related PowerShell developer tools.'
     RequiredModules = @("PSDT.App")
-    FunctionsToExport = @("Import-VSCommandPrompt","Get-VSSolution","Invoke-VSBuild","Invoke-VSTest")
+    FunctionsToExport = @("Import-VSCommandPrompt","Get-VSSolution","Invoke-VSBuild","Invoke-VSTest", "Import-VS2017Environment")
     CmdletsToExport = @("*-*")
     VariablesToExport = '*'
     AliasesToExport = @("gvss","ivsb","ivst")

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -54,7 +54,11 @@
       secure: 3uEUNJ8M0/Rdg1D2KT+XLjpWNr7QbTMO/8SjSXuAwbbeGW1UIfwLthZ0nzFSEpRl
   init:
   - ps: >-
-      Invoke-PSDTInitBuild;
+      Install-PackageProvider -Name NuGet -MinimumVersion '2.8.5.201' -Force;
+      Import-PackageProvider NuGet -MinimumVersion '2.8.5.201';
+      Set-PSRepository -Name PSGallery -InstallationPolicy Trusted;
+      Install-Module -Name PSScriptAnalyzer;
+      Install-Module -Name PSDT.AppVeyor;
   build_script:
   - ps: >-
       Invoke-PSDTPreBuild;


### PR DESCRIPTION
Short extension for search and set the MSBuild and VSTest console for VS2017 with the Visual Studio locater (vswhere). 
I have not used directly vswhere, rather the powershell module VSSetup with an easier syntax.
