### PR TITLE
#4: Import-VSCommandPrompt search path updated to search for VS 2017 …

### DIFF
--- a/PSDT.VisualStudio.psm1
+++ b/PSDT.VisualStudio.psm1
@@ -11,7 +11,7 @@ Function Import-VSCommandPrompt() {
 $env:PSDT_VSCommandPromptVariable = $null;
 
 Function VSCommandPrompt {
-    $vsDevCmd = Get-ChildItem VsDevCmd.bat -Path "C:\*\Microsoft Visual Studio*\Common7\Tools" -Recurse | Select-Object -Last 1;
+    $vsDevCmd = Get-ChildItem VsDevCmd.bat -Path "C:\*\Microsoft Visual Studio*\Common7\Tools", "C:\*\Microsoft Visual Studio\*\*\Common7\Tools" -Recurse | Select-Object -Last 1;
     $env:PSDT_VSCommandPromptVariable = $($vsDevCmd.FullName);
 
     Push-Location $vsDevCmd.DirectoryName;


### PR DESCRIPTION
Additional path to search for VsDevCmd.bat added. VS2017 uses different paths compared to older VS versions.